### PR TITLE
Change Artifacts Settings 

### DIFF
--- a/workflow-templates/bundler.yml
+++ b/workflow-templates/bundler.yml
@@ -80,18 +80,18 @@ jobs:
 
       - name: Uploading Artifacts - results
         uses: actions/upload-artifact@v4
+        if: always()  # Run even if tests fail
         with:
           name: results
           path: results
-          retention-days: 1
           overwrite: true
 
       - name: Uploading Artifacts - coverage
         uses: actions/upload-artifact@v4
+        if: always()  # Run even if tests fail
         with:
           name: coverage
           path: coverage
-          retention-days: 1
           overwrite: true
 
       - name: Upload Coverage to Codacy

--- a/workflow-templates/gradle.yml
+++ b/workflow-templates/gradle.yml
@@ -84,18 +84,18 @@ jobs:
 
       - name: Uploading Artifacts - tests
         uses: actions/upload-artifact@v4
+        if: always()  # Run even if tests fail
         with:
           name: tests
           path: build/reports/tests/test
-          retention-days: 1
           overwrite: true
 
       - name: Uploading Artifacts - jacoco
         uses: actions/upload-artifact@v4
+        if: always()  # Run even if tests fail
         with:
           name: jacoco
           path: build/reports/jacoco/test/html
-          retention-days: 1
           overwrite: true
 
       - name: Upload Coverage to Codacy

--- a/workflow-templates/maven.yml
+++ b/workflow-templates/maven.yml
@@ -96,18 +96,18 @@ jobs:
 
       - name: Uploading Artifacts - surefire-reports
         uses: actions/upload-artifact@v4
+        if: always()  # Run even if tests fail
         with:
           name: surefire-reports
           path: target/surefire-reports/
-          retention-days: 1
           overwrite: true
 
       - name: Uploading Artifacts - jacoco
         uses: actions/upload-artifact@v4
+        if: always()  # Run even if tests fail
         with:
           name: jacoco
           path: target/site/jacoco/
-          retention-days: 1
           overwrite: true
 
       - name: Upload Coverage to Codacy


### PR DESCRIPTION
The following changes are implemented to the GH Actions templates: 

- Add `if: always()` to always upload artifacts, even if tests fail. 
- Remove retention period based on [documentation](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#comparing-artifacts-and-dependency-caching).