### PR TITLE
EnricoMi test reporter and permissions to all templates

### DIFF
--- a/workflow-templates/bundler.yml
+++ b/workflow-templates/bundler.yml
@@ -6,6 +6,12 @@ on:
   push:
     branches: [$default-branch]
 
+# Permissions needed for EnricoMi test results publishing
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -93,6 +99,18 @@ jobs:
           name: coverage
           path: coverage
           overwrite: true
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()  # Run even if tests fail
+        with:
+          files: "**/results/**/*.xml"
+          check_name: "Test Results"
+          comment_mode: always
+          compare_to_earlier_commit: true
+          report_individual_runs: true
+          check_run_annotations: "all tests"
+          job_summary: true
 
       - name: Upload Coverage to Codacy
         uses: codacy/codacy-coverage-reporter-action@v1

--- a/workflow-templates/gradle.yml
+++ b/workflow-templates/gradle.yml
@@ -6,6 +6,12 @@ on:
   push:
     branches: [$default-branch]
 
+# Permissions needed for EnricoMi test results publishing
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -97,6 +103,18 @@ jobs:
           name: jacoco
           path: build/reports/jacoco/test/html
           overwrite: true
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()  # Run even if tests fail
+        with:
+          files: "**/build/test-results/**/*.xml"
+          check_name: "Test Results"
+          comment_mode: always
+          compare_to_earlier_commit: true
+          report_individual_runs: true
+          check_run_annotations: "all tests"
+          job_summary: true
 
       - name: Upload Coverage to Codacy
         uses: codacy/codacy-coverage-reporter-action@v1

--- a/workflow-templates/maven.yml
+++ b/workflow-templates/maven.yml
@@ -6,6 +6,12 @@ on:
   push:
     branches: [$default-branch]
 
+# Permissions needed for EnricoMi test results publishing
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -109,6 +115,18 @@ jobs:
           name: jacoco
           path: target/site/jacoco/
           overwrite: true
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()  # Run even if tests fail
+        with:
+          files: "**/target/surefire-reports/**/*.xml"
+          check_name: "Test Results"
+          comment_mode: always
+          compare_to_earlier_commit: true
+          report_individual_runs: true
+          check_run_annotations: "all tests"
+          job_summary: true
 
       - name: Upload Coverage to Codacy
         uses: codacy/codacy-coverage-reporter-action@v1

--- a/workflow-templates/npm.yml
+++ b/workflow-templates/npm.yml
@@ -19,9 +19,12 @@ jobs:
 
     # These permissions are required to pull organizational level private packages
     # You must grant your repo access from the package
+    # Additional permissions (checks, pull-requests) needed for EnricoMi test results publishing
     permissions:
       contents: read
       packages: read
+      checks: write
+      pull-requests: write
 
     steps:
       - name: Checkout Code
@@ -51,3 +54,15 @@ jobs:
 
       - name: Run Tests
         run: npm run test
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()  # Run even if tests fail
+        with:
+          files: "./reports/junit/**/*.xml"
+          check_name: "Test Results"
+          comment_mode: always
+          compare_to_earlier_commit: true
+          report_individual_runs: true
+          check_run_annotations: "all tests"
+          job_summary: true

--- a/workflow-templates/sbt.yml
+++ b/workflow-templates/sbt.yml
@@ -6,6 +6,12 @@ on:
   push:
     branches: [$default-branch]
 
+# Permissions needed for EnricoMi test results publishing
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -46,6 +52,18 @@ jobs:
 
       - name: Run Tests and Generate Coverage Report and Aggregate
         run: sbt coverage test coverageReport coverageAggregate
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()  # Run even if tests fail
+        with:
+          files: "target/test-reports/**/*.xml"
+          check_name: "Test Results"
+          comment_mode: always
+          compare_to_earlier_commit: true
+          report_individual_runs: true
+          check_run_annotations: "all tests"
+          job_summary: true
 
       - name: Upload Coverage to Codacy
         uses: codacy/codacy-coverage-reporter-action@v1

--- a/workflow-templates/yarn.yml
+++ b/workflow-templates/yarn.yml
@@ -19,9 +19,12 @@ jobs:
 
     # These permissions are required to pull organizational level private packages
     # You must grant your repo access from the package
+    # Additional permissions (checks, pull-requests) needed for EnricoMi test results publishing
     permissions:
       contents: read
       packages: read
+      checks: write
+      pull-requests: write
 
     steps:
       - name: Checkout Code
@@ -54,3 +57,15 @@ jobs:
 
       - name: Run Tests
         run: yarn test
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()  # Run even if tests fail
+        with:
+          files: "./reports/junit/**/*.xml"
+          check_name: "Test Results"
+          comment_mode: always
+          compare_to_earlier_commit: true
+          report_individual_runs: true
+          check_run_annotations: "all tests"
+          job_summary: true


### PR DESCRIPTION
Added the needed permissions, EnricoMi action and the generic `files: _path_` for each of the workflow templates